### PR TITLE
fix: dynamically set dividend slider range

### DIFF
--- a/final_version/project/final_project.py
+++ b/final_version/project/final_project.py
@@ -1,3 +1,4 @@
+import math
 import streamlit as st
 import pandas as pd
 from pandas_datareader import data as pdr
@@ -21,7 +22,14 @@ def parameter(df_sp,sector_default_val,cap_default_val):
     #### MARKET CAP #####
 
     #### DIVIDEND #####
-    dividend_value = st.sidebar.slider('Dividend rate between than (%) : ', 0.0, 10.0, value = (0.0,10.0))
+    dividend_min_value = float(math.floor(df_sp['dividendYield_%'].min()))
+    dividend_max_value = float(math.ceil(df_sp['dividendYield_%'].max()))
+    dividend_value = st.sidebar.slider(
+        'Dividend rate between than (%): ',
+        dividend_min_value,
+        dividend_max_value,
+        value=(dividend_min_value, dividend_max_value)
+    )
     #### DIVIDEND #####
 
     #### PROFIT #####

--- a/final_version/project/final_project_interactions.py
+++ b/final_version/project/final_project_interactions.py
@@ -1,3 +1,4 @@
+import math
 import streamlit as st
 import pandas as pd
 from pandas_datareader import data as pdr
@@ -20,7 +21,14 @@ def parameter(df_sp,sector_default_val,cap_default_val):
     #### MARKET CAP #####
 
     #### DIVIDEND #####
-    dividend_value = st.sidebar.slider('Dividend rate between than (%) : ', 0.0, 10.0, value = (0.0,10.0))
+    dividend_min_value = float(math.floor(df_sp['dividendYield_%'].min()))
+    dividend_max_value = float(math.ceil(df_sp['dividendYield_%'].max()))
+    dividend_value = st.sidebar.slider(
+        'Dividend rate between than (%): ',
+        dividend_min_value,
+        dividend_max_value,
+        value=(dividend_min_value, dividend_max_value)
+    )
     #### DIVIDEND #####
 
     #### PROFIT #####


### PR DESCRIPTION
### What

- Changed the range of the dividend slider to be dynamically set based on the minimum and maximum values present in the dataset.

### Why

- In Section 4 of the class [Streamlit : Deploy your Data & ML app on the web with Python](https://www.udemy.com/course/streamlit-deploy-your-data-ml-app-on-the-web-with-python/), the original implementation of the dividend slider was set to static values ranging from 0.0 to 10.0.
- This static range inadvertently filtered out the company Invesco Ltd., which has a `dividendYield_%` of 19.940001.
- As a result, the default view showed 490 companies instead of 491.
- This change dynamically sets the range of the dividend slider to show all available companies, including those like Invesco Ltd. with dividend yields outside of the previously static range.
